### PR TITLE
fix: change error messages to use stdout instead of stderr in execute…

### DIFF
--- a/exec_command.c
+++ b/exec_command.c
@@ -32,18 +32,18 @@ void execute_command(char *line, char *prog_name, int count)
 			/* execve a échoué */
 			if (errno == EACCES)
 			{
-				fprintf(stderr, "%s: %d: %s: Permission denied\n", prog_name, count, line);
+				fprintf(stdout, "%s: %d: %s: Permission denied\n", prog_name, count, line);
 				exit(126);
 			}
 			else if (strchr(line, '/') != NULL)
 			{
-				fprintf(stderr, "%s: %d: %s: No such file or directory\n",
+				fprintf(stdout, "%s: %d: %s: No such file or directory\n",
 					prog_name, count, line);
 				exit(2);
 			}
 			else
 			{
-				fprintf(stderr, "%s: %d: %s: not found\n", prog_name, count, line);
+				fprintf(stdout, "%s: %d: %s: not found\n", prog_name, count, line);
 				exit(127);
 			}
 		}


### PR DESCRIPTION
…_command
This pull request updates how error messages are output in the `execute_command` function within `exec_command.c`. Instead of printing errors to `stderr`, all error messages are now sent to `stdout`.

Error handling output changes:

* Changed all error message outputs in `execute_command` from `stderr` to `stdout`, affecting permission denied, file not found, and command not found scenarios.