### PR TITLE
fix: remove redundant error message for no such file or directory in …

### DIFF
--- a/exec_command.c
+++ b/exec_command.c
@@ -35,12 +35,6 @@ void execute_command(char *line, char *prog_name, int count)
 				fprintf(stdout, "%s: %d: %s: Permission denied\n", prog_name, count, line);
 				exit(126);
 			}
-			else if (strchr(line, '/') != NULL)
-			{
-				fprintf(stdout, "%s: %d: %s: No such file or directory\n",
-					prog_name, count, line);
-				exit(2);
-			}
 			else
 			{
 				fprintf(stdout, "%s: %d: %s: not found\n", prog_name, count, line);


### PR DESCRIPTION
…execute_command
This pull request makes a small change to the error handling logic in the `execute_command` function. Specifically, it removes the check for a slash (`/`) in the command line, which previously triggered a "No such file or directory" error. Now, if a command is not found, it will consistently display the "not found" message.

* Removed the conditional check for slashes in `line` and its associated "No such file or directory" error message in `exec_command.c`.